### PR TITLE
Do not modify a Hash argument to `error!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#1325](https://github.com/ruby-grape/grape/pull/1325): Params: Fix coerce_with helper with Array types - [@ngonzalez](https://github.com/ngonzalez).
 * [#1326](https://github.com/ruby-grape/grape/pull/1326): Fix wrong behavior for OPTIONS and HEAD requests with catch-all - [@ekampp](https://github.com/ekampp), [@namusyaka](https://github.com/namusyaka).
 * [#1330](https://github.com/ruby-grape/grape/pull/1330): Add `register` keyword for adding customized parsers and formatters - [@namusyaka](https://github.com/namusyaka).
+* [](): Do not modify Hash argument to `error!` - [@tjwp](https://github.com/tjwp)
 
 0.15.0 (3/8/2016)
 =================

--- a/lib/grape/error_formatter/base.rb
+++ b/lib/grape/error_formatter/base.rb
@@ -3,9 +3,13 @@ module Grape
     module Base
       def present(message, env)
         present_options = {}
-        present_options[:with] = message.delete(:with) if message.is_a?(Hash)
+        presented_message = message
+        if presented_message.is_a?(Hash) && presented_message.key?(:with)
+          present_options[:with] = presented_message[:with]
+          presented_message = presented_message.reject { |k, _| k == :with }
+        end
 
-        presenter = env[Grape::Env::API_ENDPOINT].entity_class_for_obj(message, present_options)
+        presenter = env[Grape::Env::API_ENDPOINT].entity_class_for_obj(presented_message, present_options)
 
         unless presenter || env[Grape::Env::GRAPE_ROUTING_ARGS].nil?
           # env['api.endpoint'].route does not work when the error occurs within a middleware
@@ -21,10 +25,10 @@ module Grape
         if presenter
           embeds = { env: env }
           embeds[:version] = env[Grape::Env::API_VERSION] if env[Grape::Env::API_VERSION]
-          message = presenter.represent(message, embeds).serializable_hash
+          presented_message = presenter.represent(presented_message, embeds).serializable_hash
         end
 
-        message
+        presented_message
       end
     end
   end

--- a/spec/grape/api_spec.rb
+++ b/spec/grape/api_spec.rb
@@ -2046,7 +2046,7 @@ XML
     end
 
     it 'presented with' do
-      error = { code: 408, with: error_presenter }
+      error = { code: 408, with: error_presenter }.freeze
       subject.get '/exception' do
         error! error, 408
       end

--- a/spec/grape/endpoint_spec.rb
+++ b/spec/grape/endpoint_spec.rb
@@ -742,6 +742,16 @@ describe Grape::Endpoint do
       expect(last_response.body).to eq('{"dude":"rad"}')
     end
 
+    it 'accepts a frozen object' do
+      subject.get '/hey' do
+        error!({ 'dude' => 'rad' }.freeze, 403)
+      end
+
+      get '/hey.json'
+      expect(last_response.status).to eq(403)
+      expect(last_response.body).to eq('{"dude":"rad"}')
+    end
+
     it 'can specifiy headers' do
       subject.get '/hey' do
         error!({ 'dude' => 'rad' }, 403, 'X-Custom' => 'value')


### PR DESCRIPTION
This change allows an immutable hash, for example a frozen constant, to be passed as the message to `error!`.

If a `:with` value needs to removed from the specified message then a new hash is created without the key.
